### PR TITLE
Benchmark int future vs. generic future

### DIFF
--- a/futures/future_test.go
+++ b/futures/future_test.go
@@ -1,0 +1,28 @@
+package futures
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkIntFuture(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		f := CreateIntFuture(func() int {
+			time.Sleep(5 * time.Millisecond)
+			return 5
+		})
+		f.Get()
+	}
+}
+
+func BenchmarkGenericFuture(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		f := NewFuture(func() int {
+			time.Sleep(5 * time.Millisecond)
+			return 5
+		})
+		f.Get()
+	}
+}

--- a/futures/int_future.go
+++ b/futures/int_future.go
@@ -1,0 +1,35 @@
+package futures
+
+import (
+	"time"
+	"fmt"
+)
+
+type IntFuture struct {
+	outChan chan int
+}
+
+func CreateIntFuture(fetch func() int) *IntFuture {
+	outChan := make(chan int, 1)
+	future := &IntFuture{}
+	future.outChan = outChan
+	go func() {
+		outChan <- fetch()
+	}()
+	return future
+}
+
+func (f *IntFuture) Get() (int, error) {
+	x := <- f.outChan
+	return x, nil
+}
+
+func (f *IntFuture) GetWithTimeout(timeout time.Duration) (int, error) {
+	select {
+		case x := <-f.outChan:
+			return x, nil
+		case <-time.After(timeout):
+	}
+
+	return -1, fmt.Errorf("future timed out")
+}


### PR DESCRIPTION
```
root@2346d99a642d:/go/src/go-futures# go test -bench=. go-futures/futures/...
goos: linux
goarch: amd64
pkg: go-futures/futures
BenchmarkIntFuture-2       	     214	   5835022 ns/op	     184 B/op	       3 allocs/op
BenchmarkGenericFuture-2   	     196	   5983962 ns/op	     265 B/op	       6 allocs/op
PASS
ok  	go-futures/futures	3.616s
```

Latency wise there isn't much of a difference, but there's a significant difference in allocation